### PR TITLE
When closing ports, remove port from _engine._inMap to allow re-openi…

### DIFF
--- a/javascript/JZZ.js
+++ b/javascript/JZZ.js
@@ -64,6 +64,9 @@
     var ret = new _R();
     if (this._close) this._push(this._close, []);
     this._push(_close, [ret]);
+    if (_engine && this._impl && _engine._inMap[this._impl.name]) {
+      delete _engine._inMap[this._impl.name];
+    }
     return ret;
   }
 


### PR DESCRIPTION
When closing ports, remove port from _engine._inMap to allow re-opening the port

*this can support users using JZZ in multiple windows at once by closing ports on window.blur and re-opening them on window.focus events



See this thread: http://jazz-soft.org/bb/viewtopic.php?f=9&t=954