### PR TITLE
Update .gitignore to include dev artifact files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+package-lock.json
+.nyc_output


### PR DESCRIPTION
Adding dev files not tracked in git
* `package-lock.json`: an artifact of `npm install`
* `.nyc_output`: an artifact of `npm test`