### PR TITLE
Unify midi channel error messaging

### DIFF
--- a/javascript/JZZ.js
+++ b/javascript/JZZ.js
@@ -378,7 +378,7 @@
   };
   _M.prototype.ch = function(n) {
     if (typeof n == 'undefined') return this;
-    if (n != parseInt(n) || n < 0 || n > 15) throw RangeError('Bad channel value: ' + n  + ' (must be from 0 to 15)');
+    _validateChannel(n);
     var chan = new _C(this, n);
     this._push(_kick, [chan]);
     return chan;
@@ -395,6 +395,10 @@
     this._push(_kick, [chan]);
     return chan;
   };
+  function _validateChannel(c) {
+    if (c != parseInt(c) || c < 0 || c > 15)
+      throw RangeError('Bad channel value (must not be less than 0 or more than 15): ' + c);
+  }
 
   // _C: MIDI Channel object
   function _C(port, chan) {
@@ -1463,7 +1467,7 @@
   }
   for (n = 0; n < 128; n++) _noteNum[n] = n;
   function _throw(x) { throw RangeError('Bad MIDI value: ' + x); }
-  function _ch(n) { if (n != parseInt(n) || n < 0 || n > 0xf) _throw(n); return parseInt(n); }
+  function _ch(c) { _validateChannel(c); return parseInt(c); }
   function _7b(n, m) { if (n != parseInt(n) || n < 0 || n > 0x7f) _throw(typeof m == 'undefined' ? n : m); return parseInt(n); }
   function _8b(n, m) { if (n != parseInt(n) || n < 0 || n > 0xff) _throw(typeof m == 'undefined' ? n : m); return parseInt(n); }
   function _lsb(n) { if (n != parseInt(n) || n < 0 || n > 0x3fff) _throw(n); return parseInt(n) & 0x7f; }
@@ -1556,7 +1560,7 @@
     smfDevName: function(dd) { return _smf(9, JZZ.lib.toUTF8(dd)); },
     smfChannelPrefix: function(dd) {
       if (dd == parseInt(dd)) {
-        if (dd < 0 || dd > 15) throw RangeError('Channel number out of range: ' + dd);
+        _validateChannel(dd);
         dd = String.fromCharCode(dd);
       }
       else {

--- a/test/common.js
+++ b/test/common.js
@@ -190,6 +190,30 @@ describe('MIDI messages', function() {
   it('freq', function() {
     assert.equal(JZZ.MIDI.freq('A6'), 880);
   });
+  it('channel error handling for non-integer value', function() {
+    try {
+      JZZ.MIDI.noteOn(0.5, 'C4', 99);
+      assert.fail('expected midi channel value to be invalid');
+    } catch(error) {
+      assert.equal(error.constructor, RangeError);
+    }
+  });
+  it('channel error handling for low value', function() {
+    try {
+      JZZ.MIDI.noteOn(-1, 'C4', 99);
+      assert.fail('expected midi channel value to be invalid');
+    } catch(error) {
+      assert.equal(error.constructor, RangeError);
+    }
+  });
+  it('channel error handling for high value', function() {
+    try {
+      JZZ.MIDI.noteOn(16, 'C4', 99);
+      assert.fail('expected midi channel value to be invalid');
+    } catch(error) {
+      assert.equal(error.constructor, RangeError);
+    }
+  });
 });
 
 describe('SMF events', function() {


### PR DESCRIPTION
I had an error in a unit test for my app that uses JZZ. The failure read:
```
Bad MIDI value: 60
```
After digging into `JZZ.js` I realized that the issue was that I was passing in a note value where a channel value was expected ([see in file](https://github.com/jazz-soft/JZZ/blob/6fed191276ac1ce24484eadaad977b734f8d8505/javascript/JZZ.js#L1465-L1466)):
```
  function _throw(x) { throw RangeError('Bad MIDI value: ' + x); }
  function _ch(n) { if (n != parseInt(n) || n < 0 || n > 0xf) _throw(n); return parseInt(n); }
```
 Then I happened to notice that another place in `JZZ.js` had a more instructive error message for a similar situation ([see in file](https://github.com/jazz-soft/JZZ/blob/6fed191276ac1ce24484eadaad977b734f8d8505/javascript/JZZ.js#L381)):
```
if (n != parseInt(n) || n < 0 || n > 15) throw RangeError('Bad channel value: ' + n  + ' (must be from 0 to 15)');
```
And I thought to myself: "hey, that would have helped me find the bug in my code quicker". So, I figured it might be nice for posterity if I unified the messaging (and validation logic, since it's the same) to be more like that instructive messaging. Also, it's more "DRY" :)