### PR TITLE
Avoid navigator.requestMIDIAccess

### DIFF
--- a/javascript/JZZ.js
+++ b/javascript/JZZ.js
@@ -610,7 +610,7 @@
         self._crash(msg);
       };
       var opt = {};
-      _requestMIDIAccess(opt).then(onGood, onBad);
+      navigator.requestMIDIAccess(opt).then(onGood, onBad);
       this._pause();
       return;
     }
@@ -627,7 +627,7 @@
         self._crash(msg);
       };
       var opt = {sysex:true};
-      _requestMIDIAccess(opt).then(onGood, onBad);
+      navigator.requestMIDIAccess(opt).then(onGood, onBad);
       this._pause();
       return;
     }


### PR DESCRIPTION
This patch avoids the following exception.
TypeError: Failed to execute 'requestMIDIAccess' on 'Navigator': Illegal invocation

This seems to occur when attempting to use JZZ from a ReactJS component.
Addresses issue https://github.com/jazz-soft/JZZ/issues/22